### PR TITLE
Enable experimental supprot for the Test Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
                 "type": "object",
                 "title": "Calva",
                 "properties": {
+                    "calva.useTestExplorer": {
+                        "type": "boolean",
+                        "description": "Enable experimental support for the VSCode Test Explorer",
+                        "default": false
+                    },
                     "calva.prettyPrintingOptions": {
                         "type": "object",
                         "description": "Settings for Calva's pretty printing",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,7 @@ import * as edit from './edit';
 import * as nreplLogging from './nrepl/logging';
 
 import * as clojureDocs from './clojuredocs';
-async function onDidSave(document) {
+async function onDidSave(testController: vscode.TestController, document: vscode.TextDocument) {
     let {
         evaluate,
         test,
@@ -47,7 +47,7 @@ async function onDidSave(document) {
     }
 
     if (test && util.getConnectedState()) {
-        testRunner.runNamespaceTests(document);
+        testRunner.runNamespaceTests(testController, document);
         state.analytics().logEvent("Calva", "OnSaveTest").send();
     } else if (evaluate) {
         if (!outputWindow.isResultsDoc(document)) {
@@ -86,14 +86,19 @@ async function activate(context: vscode.ExtensionContext) {
     initializeState();
 
     status.updateNeedReplUi(false, context);
-    lsp.activate(context);
+
+
+    const controller = vscode.tests.createTestController('calvaTestController', 'Clojure Cider')
+    context.subscriptions.push(controller);
+
+    lsp.activate(context, testTree => { testRunner.onTestTree(controller, testTree) });
+
     setStateValue('analytics', new Analytics(context));
     state.analytics().logPath("/start").logEvent("LifeCycle", "Started").send();
 
     model.initScanner(vscode.workspace.getConfiguration('editor').get('maxTokenizationLineLength'));
 
     const chan = state.outputChannel();
-
     const legacyExtension = vscode.extensions.getExtension('cospaia.clojure4vscode');
     const fmtExtension = vscode.extensions.getExtension('cospaia.calva-fmt');
     const pareEditExtension = vscode.extensions.getExtension('cospaia.paredit-revived');
@@ -119,6 +124,8 @@ async function activate(context: vscode.ExtensionContext) {
                 }
             })
     }
+
+    testRunner.initialize(controller);
 
     if (legacyExtension) {
         vscode.window.showErrorMessage("Calva Legacy extension detected. Things will break. Please uninstall, or disable, the old Calva extension.", "Roger that. Right away!")
@@ -187,10 +194,10 @@ async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateSelectionAsComment', eval.evaluateSelectionAsComment));
     context.subscriptions.push(vscode.commands.registerCommand('calva.evaluateTopLevelFormAsComment', eval.evaluateTopLevelFormAsComment));
     context.subscriptions.push(vscode.commands.registerCommand('calva.togglePrettyPrint', eval.togglePrettyPrint));
-    context.subscriptions.push(vscode.commands.registerCommand('calva.runTestUnderCursor', testRunner.runTestUnderCursorCommand));
-    context.subscriptions.push(vscode.commands.registerCommand('calva.runNamespaceTests', testRunner.runNamespaceTestsCommand));
-    context.subscriptions.push(vscode.commands.registerCommand('calva.runAllTests', testRunner.runAllTestsCommand));
-    context.subscriptions.push(vscode.commands.registerCommand('calva.rerunTests', testRunner.rerunTestsCommand));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.runTestUnderCursor', () => { testRunner.runTestUnderCursorCommand(controller) }));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.runNamespaceTests', () => { testRunner.runNamespaceTestsCommand(controller) }));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.runAllTests', () => { testRunner.runAllTestsCommand(controller) }));
+    context.subscriptions.push(vscode.commands.registerCommand('calva.rerunTests', () => { testRunner.rerunTestsCommand(controller) }));
     context.subscriptions.push(vscode.commands.registerCommand('calva.clearInlineResults', annotations.clearEvaluationDecorations));
     context.subscriptions.push(vscode.commands.registerCommand('calva.copyAnnotationHoverText', annotations.copyHoverTextCommand));
     context.subscriptions.push(vscode.commands.registerCommand('calva.copyLastResults', eval.copyLastResultCommand));
@@ -254,7 +261,7 @@ async function activate(context: vscode.ExtensionContext) {
         onDidOpen(document);
     }));
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((document) => {
-        onDidSave(document);
+        onDidSave(controller, document);
     }));
     context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor((editor) => {
         status.update();

--- a/src/nrepl/cider.ts
+++ b/src/nrepl/cider.ts
@@ -14,7 +14,7 @@ export interface TestResult {
     index: number;
     message: string;
     ns: string;
-    type: string;
+    type: 'pass' | 'fail' | 'error';
     var: string;
     expected?: string;
     'gen-input'?: string;
@@ -125,4 +125,19 @@ export function detailedMessage(result: TestResult): string {
 // Return a short message that can be shown to user as a Diagnostic.
 export function diagnosticMessage(result: TestResult): string {
     return `failure in test: ${result.var} context: ${result.context}, expected ${result.expected}, got: ${result.actual}`
+}
+
+export function shortMessage(result: TestResult): string {
+    switch (result.type) {
+        case 'pass':
+            return '';
+        case 'error':
+            return 'Error running test: ' + result.message + ' ' + result.error;
+        case 'fail':
+            if (result.message) {
+                return 'Expected ' + result.expected + ' actual ' + result.actual
+            } else {
+                return result.message + ' expected ' + result.expected + ' actual ' + result.actual;
+            }
+    }
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -21,6 +21,10 @@ export function escapeStringRegexp(s: string): string {
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+export function isNonEmptyString(value: any): boolean {
+    return typeof (value) == 'string' && value.length > 0
+}
+
 async function quickPickSingle(opts: { values: string[], saveAs?: string, placeHolder: string, autoSelect?: boolean }) {
     if (opts.values.length == 0)
         return;
@@ -414,7 +418,14 @@ export async function isDocumentWritable(document: vscode.TextDocument): Promise
     return (fileStat.permissions & vscode.FilePermission.Readonly) !== 1;
 }
 
+// Returns the elements of coll with duplicates removed
+// (See clojure.core/distinct).
+function distinct<T>(coll: T[]): T[] {
+    return [... new Set(coll)];
+}
+
 export {
+    distinct,
     getWordAtPosition,
     getDocument,
     getFileType,


### PR DESCRIPTION
This is currently disabled behind the `calva.useTestExplorer` flag while
we test it.

Enable the Test Explorer view. This is a first pass and there are
missing features:

- [ ] The UI that pops up is jarring - can we collapse it?
- [ ] Test discovery using clojure-lsp
- [ ] Assertions have the name '0'

Fixes: #953

Enable re-test

First pass at re-run support